### PR TITLE
Fix issue #16.

### DIFF
--- a/cmd/spctl/command/root.go
+++ b/cmd/spctl/command/root.go
@@ -30,7 +30,7 @@ func printHelpAndExit(cmd *cobra.Command) {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&globalFlags.PMSEndpoint, "pms-endpoint", flags.DefaultPolicyMgmtEndPoint, "speedle policy managemnet service endpoint")
+	rootCmd.PersistentFlags().StringVar(&globalFlags.PMSEndpoint, "pms-endpoint", flags.DefaultPolicyManagmentConnectEndpoint, "speedle policy managemnet service endpoint")
 	rootCmd.PersistentFlags().DurationVar(&globalFlags.Timeout, "timeout", 5000000000, "timeout for running command")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.CertFile, "cert", "", "identify secure client using this TLS certificate file")
 	rootCmd.PersistentFlags().StringVar(&globalFlags.KeyFile, "key", "", "identify secure client using this TLS key file")

--- a/cmd/speedle-pms/main.go
+++ b/cmd/speedle-pms/main.go
@@ -42,7 +42,7 @@ func main() {
 	storeParamsMap := store.GetAllStoreParams()
 
 	var params flags.Parameters
-	params.ParseFlags(flags.DefaultPolicyMgmtEndPoint, printVersionInfo, storeParamsMap)
+	params.ParseFlags(flags.DefaultPolicyManagementListenPoint, printVersionInfo, storeParamsMap)
 	params.ValidateFlags()
 
 	conf, _ := params.Param2Config(storeParamsMap)

--- a/pkg/cmd/flags/params.go
+++ b/pkg/cmd/flags/params.go
@@ -74,10 +74,15 @@ type AsserterParameters struct {
 }
 
 const (
-	DefaultPolicyMgmtEndPoint = "0.0.0.0:6733"
-	DefaultAuthzCheckEndPoint = "0.0.0.0:6734"
-	DefaultInsecure           = true
-	DefaultEnableAuthz        = false
+	// DefaultPolicyManagementListenPoint is a constant that is the default value for PMS.
+	// If arguments --endpoint is not passed, use this default value.
+	DefaultPolicyManagementListenPoint = "0.0.0.0:6733"
+	// DefaultPolicyManagmentConnectEndpoint is a constant that is the default value for command line tool spctl.
+	// If command line argument --pms-endpint and no pms-endpint defined in configure file, use this default value.
+	DefaultPolicyManagmentConnectEndpoint = "http://127.0.0.1:6733/policy-mgmt/v1/"
+	DefaultAuthzCheckEndPoint             = "0.0.0.0:6734"
+	DefaultInsecure                       = true
+	DefaultEnableAuthz                    = false
 
 	DefaultStoreType = cfg.StorageTypeFile //file
 

--- a/testutil/restTestUtil.go
+++ b/testutil/restTestUtil.go
@@ -361,7 +361,7 @@ func NewRestClient(endpoint string, curToken string, basicAuthName string, basic
 //Get RestClient for policy management
 func NewRestClient_PMS() *RestClient {
 
-	pmsEndpoint := GetOSEnv(PMS_ENDPOINT, "http://"+flags.DefaultPolicyMgmtEndPoint)
+	pmsEndpoint := GetOSEnv(PMS_ENDPOINT, "http://"+flags.DefaultPolicyManagmentConnectEndpoint)
 	pmsAdminToken := GetOSEnv(PMS_ADMIN_TOKEN, "")
 
 	TestLog.Logf("PMSEndpoint=%s, token=%s \n", pmsEndpoint, pmsAdminToken)


### PR DESCRIPTION
Seperate DefaultPolicyMgmtEndPoint to two constants, Seperate DefaultPolicyMgmtEndPoint to two constants, this will avoid confusing to programmers.
The one is DefaultPolicyManagementListenPoint which is for PMS, and the other one is DefaultPolicyManagmentConnectEndpoint which is for spctl or PMS clients.