### PR TITLE
fix: fail closed when deny policy condition cannot be evaluated

### DIFF
--- a/pkg/eval/evaluator.go
+++ b/pkg/eval/evaluator.go
@@ -453,7 +453,17 @@ func (p *PolicyEvalImpl) getDirectRolePoliciesInService(principals []string,
 			if condition != nil {
 				r, e := evaluateCondition(condition, attributes)
 				if e != nil {
-					log.Debugf("condition evaluation error for role policy: %v", e)
+					log.Warnf("Error evaluating condition for role policy %s: %v", policy.Name, e)
+					// Fail closed: when a deny role policy's condition cannot be
+					// evaluated, apply the denial rather than silently dropping
+					// it (which would fail open).
+					if policy.Effect == pms.Deny {
+						if evaluationResult != nil {
+							evaluationResult.AddRolePolicy(policy, true)
+						}
+						deniedRolePolicies = append(deniedRolePolicies, policy)
+						continue
+					}
 				}
 				result = r
 			}
@@ -992,6 +1002,13 @@ func (p *PolicyEvalImpl) getPolicyList(ctx *internalRequestContext, matchResourc
 					result, evalErr = evaluateCondition(condition, ctx.Attributes)
 					if evalErr != nil {
 						log.Warnf("Error evaluating condition for policy %s: %v", policy.Name, evalErr)
+						// Fail closed: when a deny policy's condition cannot be
+						// evaluated, apply the denial rather than silently
+						// dropping it (which would fail open and grant access).
+						if policy.Effect == pms.Deny {
+							deniedPolicyList = append(deniedPolicyList, policy)
+							continue
+						}
 					}
 				}
 

--- a/pkg/eval/evaluator_test.go
+++ b/pkg/eval/evaluator_test.go
@@ -854,6 +854,63 @@ func TestIsAllowed_empty(t *testing.T) {
 	}
 }
 
+// TestDenyConditionFailClosed verifies that when a deny policy's condition
+// cannot be evaluated (e.g., a referenced attribute is missing), the denial is
+// still applied (fail-closed) rather than silently dropped (fail-open).
+func TestDenyConditionFailClosed(t *testing.T) {
+	alice := adsapi.Subject{
+		Principals: []*adsapi.Principal{
+			{Type: adsapi.PRINCIPAL_TYPE_USER, Name: "alice"},
+		},
+	}
+	// Grant alice read on /secret, but deny it when blocked == true.
+	// The deny condition references "blocked", which the request omits, so the
+	// condition evaluation fails. The deny must still take effect.
+	stream := `
+	{
+		"services": [
+		{
+			"name": "erp",
+			"policies": [
+			{
+				"id": "grant-read",
+				"effect": "grant",
+				"principals": [["user:alice"]],
+				"permissions": [{"resource": "/secret", "actions": ["read"]}]
+			},
+			{
+				"id": "deny-when-blocked",
+				"effect": "deny",
+				"principals": [["user:alice"]],
+				"permissions": [{"resource": "/secret", "actions": ["read"]}],
+				"condition": "blocked == true"
+			}
+			]
+		}
+		]
+	}`
+	preparePolicyDataInStore([]byte(stream), t)
+	eval, err := NewWithStore(conf, testPS)
+	if err != nil {
+		t.Fatalf("error creating evaluator: %v", err)
+	}
+	// Request omits the "blocked" attribute, so the deny condition errors.
+	req := adsapi.RequestContext{
+		Subject:     &alice,
+		ServiceName: "erp",
+		Resource:    "/secret",
+		Action:      "read",
+		Attributes:  map[string]interface{}{},
+	}
+	isAllowed, _, err := eval.IsAllowed(req)
+	if err != nil {
+		t.Fatalf("error in IsAllowed: %v", err)
+	}
+	if isAllowed {
+		t.Errorf("expected DENY (fail-closed) when deny condition cannot be evaluated, but got ALLOW")
+	}
+}
+
 func TestEntityPrincipal(t *testing.T) {
 	mysql := adsapi.Subject{
 		Principals: []*adsapi.Principal{


### PR DESCRIPTION
## Security Fix (Critical)

When a deny policy's condition errored during evaluation (e.g., a referenced attribute missing from the request), the code silently dropped the deny — **fail-open authorization bypass**.

### Attack scenario
A deny policy `deny user alice read /secret if blocked == true`. Alice sends a request **without** the `blocked` attribute → condition evaluation fails → deny dropped → Alice gets access.

### Fix
Deny policies/role policies now **fail closed**: condition error applies the denial. Grant policies continue to fail closed (not granted). Added `TestDenyConditionFailClosed`.

🤖 Generated with Claude Code