### PR TITLE
fix: prevent self-deadlock in recompile condition at runtime

### DIFF
--- a/pkg/eval/evaluator_test.go
+++ b/pkg/eval/evaluator_test.go
@@ -6,7 +6,9 @@ package eval
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/teramoby/speedle-plus/3rdparty/github.com/Knetic/govaluate"
 	adsapi "github.com/teramoby/speedle-plus/api/ads"
 	"github.com/teramoby/speedle-plus/api/pms"
 )
@@ -908,6 +910,78 @@ func TestDenyConditionFailClosed(t *testing.T) {
 	}
 	if isAllowed {
 		t.Errorf("expected DENY (fail-closed) when deny condition cannot be evaluated, but got ALLOW")
+	}
+}
+
+// TestRecompileConditionNoDeadlock verifies that evaluating a policy whose
+// compiled condition is missing from the cache (which happens after a custom
+// function is deleted and the conditions cache is cleared) does not deadlock.
+// The recompile-at-runtime path must not acquire a write lock while the caller
+// holds read locks on the same mutexes.
+func TestRecompileConditionNoDeadlock(t *testing.T) {
+	alice := adsapi.Subject{
+		Principals: []*adsapi.Principal{
+			{Type: adsapi.PRINCIPAL_TYPE_USER, Name: "alice"},
+		},
+	}
+	stream := `
+	{
+		"services": [
+		{
+			"name": "erp",
+			"policies": [
+			{
+				"id": "grant-with-condition",
+				"effect": "grant",
+				"principals": [["user:alice"]],
+				"permissions": [{"resource": "/node1", "actions": ["read"]}],
+				"condition": "request_year > 2000"
+			}
+			]
+		}
+		]
+	}`
+	preparePolicyDataInStore([]byte(stream), t)
+	evalImpl, err := NewWithStore(conf, testPS)
+	if err != nil {
+		t.Fatalf("error creating evaluator: %v", err)
+	}
+	pe, ok := evalImpl.(*PolicyEvalImpl)
+	if !ok {
+		t.Fatalf("evaluator is not *PolicyEvalImpl")
+	}
+	// Clear the compiled conditions cache to force the recompile-at-runtime
+	// path on the next evaluation (simulates the post function-delete state).
+	pe.RuntimePolicyStore.Lock()
+	if rtSvc, found := pe.RuntimePolicyStore.RuntimeServices["erp"]; found {
+		rtSvc.Lock()
+		rtSvc.PoliciesCache.Conditions = make(map[string]*govaluate.EvaluableExpression)
+		rtSvc.Unlock()
+	}
+	pe.RuntimePolicyStore.Unlock()
+
+	req := adsapi.RequestContext{
+		Subject: &alice, ServiceName: "erp", Resource: "/node1", Action: "read",
+		Attributes: map[string]interface{}{},
+	}
+
+	// Run in a goroutine with a timeout; before the fix this self-deadlocks.
+	done := make(chan bool, 1)
+	go func() {
+		isAllowed, _, err := evalImpl.IsAllowed(req)
+		if err != nil {
+			t.Errorf("error in IsAllowed: %v", err)
+		}
+		if !isAllowed {
+			t.Errorf("expected ALLOW, got DENY")
+		}
+		done <- true
+	}()
+	select {
+	case <-done:
+		// completed without deadlock
+	case <-time.After(5 * time.Second):
+		t.Fatal("IsAllowed deadlocked on the recompile-at-runtime path")
 	}
 }
 

--- a/pkg/eval/runtimeservice.go
+++ b/pkg/eval/runtimeservice.go
@@ -89,44 +89,21 @@ func (rtps *RuntimePolicyStore) deleteService(serviceName string) {
 	delete(rtps.RuntimeServices, serviceName)
 }
 
+// recompilePolicyConditionAtRuntime compiles a policy's condition on the fly
+// during evaluation. It intentionally does NOT write the compiled expression
+// back into the cache: the callers (getPolicyList, etc.) already hold read
+// locks on both the RuntimePolicyStore and the RuntimeService, so acquiring a
+// write lock here would self-deadlock. The compiled expression is returned for
+// one-shot use; the cache is (re)populated by the add/reload code paths.
 func (rtps *RuntimePolicyStore) recompilePolicyConditionAtRuntime(serviceName string, policy *pms.Policy) (*govaluate.EvaluableExpression, error) {
-
-	condition, err := compileCondition(policy.Condition, rtps.Functions)
-	if err == nil {
-		// Look up the service under RLock, then release before acquiring
-		// the service lock to avoid lock-ordering deadlock risks.
-		rtps.RLock()
-		rtService, ok := rtps.RuntimeServices[serviceName]
-		rtps.RUnlock()
-		if ok {
-			rtService.Lock()
-			rtService.PoliciesCache.Conditions[policy.ID] = condition
-			rtService.Unlock()
-		} else {
-			log.Errorf("Unable find service %s in runtime cache.", serviceName)
-		}
-	}
-	return condition, err
+	return compileCondition(policy.Condition, rtps.Functions)
 }
 
+// recompileRolePolicyConditionAtRuntime is the role-policy analogue of
+// recompilePolicyConditionAtRuntime and is likewise side-effect free for the
+// same lock-safety reasons.
 func (rtps *RuntimePolicyStore) recompileRolePolicyConditionAtRuntime(serviceName string, policy *pms.RolePolicy) (*govaluate.EvaluableExpression, error) {
-
-	condition, err := compileCondition(policy.Condition, rtps.Functions)
-	if err == nil {
-		// Look up the service under RLock, then release before acquiring
-		// the service lock to avoid lock-ordering deadlock risks.
-		rtps.RLock()
-		rtService, ok := rtps.RuntimeServices[serviceName]
-		rtps.RUnlock()
-		if ok {
-			rtService.Lock()
-			rtService.RolePoliciesCache.Conditions[policy.ID] = condition
-			rtService.Unlock()
-		} else {
-			log.Errorf("Unable find service %s in runtime cache.", serviceName)
-		}
-	}
-	return condition, err
+	return compileCondition(policy.Condition, rtps.Functions)
 }
 
 func (rtps *RuntimePolicyStore) addPolicy(serviceName string, policy *pms.Policy) {


### PR DESCRIPTION
## Concurrency Fix (Critical)

`recompile*ConditionAtRuntime` acquired a service write lock while the caller already held that service's read lock — a guaranteed self-deadlock.

### Trigger
After a custom function is deleted, `clearConditionsCache` wipes compiled conditions. The next evaluation of a conditional policy hits the recompile path and hangs forever.

### Fix
Made both recompile functions side-effect free (compile and return). Cache is repopulated by add/reload paths. Added `TestRecompileConditionNoDeadlock` (runs under -race with timeout).

🤖 Generated with Claude Code