### PR TITLE
fix: SSRF redirect bypass, ReDoS guard, MongoDB filter injection, unbounded caches, panic stack traces

### DIFF
--- a/pkg/eval/evaluator.go
+++ b/pkg/eval/evaluator.go
@@ -4,6 +4,7 @@
 package eval
 
 import (
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -1326,7 +1327,7 @@ func (p *PolicyEvalImpl) cleanExpiredFunctionResultPeriodically() {
 		defer p.wg.Done()
 		defer func() {
 			if r := recover(); r != nil {
-				log.Errorf("Panic in cleanExpiredFunctionResultPeriodically goroutine: %v", r)
+				log.Errorf("Panic in cleanExpiredFunctionResultPeriodically goroutine: %v\n%s", r, debug.Stack())
 			}
 			ticker.Stop()
 		}()

--- a/pkg/eval/evaluator_custom_function.go
+++ b/pkg/eval/evaluator_custom_function.go
@@ -31,7 +31,8 @@ const (
 var (
 	// Shared HTTP client with connection pooling for plain HTTP calls.
 	defaultHTTPClient = &http.Client{
-		Timeout: defaultCustomerFunctionCallTimeout,
+		Timeout:       defaultCustomerFunctionCallTimeout,
+		CheckRedirect: ssrfSafeRedirectCheck,
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 20,
 			Proxy:               http.ProxyFromEnvironment,
@@ -66,8 +67,9 @@ func getHTTPSClient(ca string) *http.Client {
 			MaxIdleConnsPerHost:   20,
 	}
 	client := &http.Client{
-		Transport: transport,
-		Timeout:   defaultCustomerFunctionCallTimeout,
+		Transport:     transport,
+		Timeout:       defaultCustomerFunctionCallTimeout,
+		CheckRedirect: ssrfSafeRedirectCheck,
 	}
 	actual, _ := httpsClients.LoadOrStore(ca, client)
 	if c2, ok2 := actual.(*http.Client); ok2 {
@@ -110,8 +112,19 @@ func (frc *FuncResultCache) add(key string, value FuncResult) {
 	frc.Results[key] = value
 }
 
+// maxFuncResultCacheSize is the maximum number of entries in the function result cache.
+// When this limit is reached, new results are not cached (callers still get the result).
+const maxFuncResultCacheSize = 50000
+
 func (frc *FuncResultCache) AddToCache(key string, cf *pms.Function, result interface{}) {
 	if cf.ResultCachable {
+		// Skip caching if the cache has grown too large to prevent unbounded memory use.
+		frc.RLock()
+		size := len(frc.Results)
+		frc.RUnlock()
+		if size > maxFuncResultCacheSize {
+			return
+		}
 		ttl := int64(0)
 		if cf.ResultTTL > 0 {
 			ttl = time.Now().Unix() + cf.ResultTTL
@@ -211,6 +224,13 @@ func hasPrivateIP(hostport string) bool {
 		}
 	}
 	return false
+}
+
+// ssrfSafeRedirectCheck validates each redirect target against SSRF rules.
+// It is used as the CheckRedirect function on HTTP clients to prevent
+// open-redirect-based SSRF bypasses.
+func ssrfSafeRedirectCheck(req *http.Request, via []*http.Request) error {
+	return validateCustomerFunctionURL(req.URL.String())
 }
 
 // validateCustomerFunctionURL checks that a function URL is safe to call.

--- a/pkg/eval/evaluator_factory.go
+++ b/pkg/eval/evaluator_factory.go
@@ -4,6 +4,8 @@
 package eval
 
 import (
+	"runtime/debug"
+
 	"github.com/teramoby/speedle-plus/pkg/cfg"
 	"github.com/teramoby/speedle-plus/pkg/store"
 
@@ -85,7 +87,7 @@ func NewWithStore(conf *cfg.Config, s pms.PolicyStoreManagerADS) (InternalEvalua
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					log.Errorf("panic in updateRuntimeCacheWithStoreChange goroutine: %v", r)
+					log.Errorf("panic in updateRuntimeCacheWithStoreChange goroutine: %v\n%s", r, debug.Stack())
 				}
 			}()
 			p.updateRuntimeCacheWithStoreChange(updateChan)

--- a/pkg/eval/evaluator_utils.go
+++ b/pkg/eval/evaluator_utils.go
@@ -6,6 +6,7 @@ package eval
 import (
 	"regexp"
 	"sync"
+	"sync/atomic"
 
 	"github.com/teramoby/speedle-plus/3rdparty/github.com/Knetic/govaluate"
 	adsapi "github.com/teramoby/speedle-plus/api/ads"
@@ -13,13 +14,28 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	compiledRegexCache sync.Map
+const (
+	// maxRegexCacheSize is the maximum number of entries in the compiled regex cache.
+	// When this limit is reached, new patterns are still compiled but not cached.
+	maxRegexCacheSize = 10000
 )
+
+var (
+	compiledRegexCache     sync.Map
+	compiledRegexCacheSize int64 // atomic counter
+)
+
+// maxRegexPatternLen is the maximum allowed length for a regex pattern.
+// Patterns longer than this are rejected to prevent resource exhaustion.
+const maxRegexPatternLen = 1024
 
 // matchRegexCompiled compiles the pattern once and caches the result.
 // It returns true if pattern matches s.
 func matchRegexCompiled(pattern, s string) bool {
+	if len(pattern) > maxRegexPatternLen {
+		log.Warnf("regex pattern exceeds maximum length of %d: len=%d", maxRegexPatternLen, len(pattern))
+		return false
+	}
 	re, ok := compiledRegexCache.Load(pattern)
 	if !ok {
 		var err error
@@ -27,7 +43,14 @@ func matchRegexCompiled(pattern, s string) bool {
 		if err != nil {
 			return false
 		}
-		re, _ = compiledRegexCache.LoadOrStore(pattern, re)
+		// Only cache if we haven't exceeded the maximum cache size.
+		if atomic.LoadInt64(&compiledRegexCacheSize) < maxRegexCacheSize {
+			var loaded bool
+			re, loaded = compiledRegexCache.LoadOrStore(pattern, re)
+			if !loaded {
+				atomic.AddInt64(&compiledRegexCacheSize, 1)
+			}
+		}
 	}
 	compiled, ok := re.(*regexp.Regexp)
 	if !ok {
@@ -47,10 +70,6 @@ func matchResource(requestRes string, resources, resExpressions []string) bool {
 			return true
 		}
 	}
-	// NOTE: Resource expressions are user-supplied and compiled as regex patterns.
-	// If untrusted users can define resource expressions, they may be able to craft
-	// patterns that cause ReDoS (catastrophic backtracking). Consider adding a timeout
-	// or complexity limit on user-supplied patterns if this becomes a concern.
 	for _, resExp := range resExpressions {
 		if matchRegexCompiled(resExp, requestRes) {
 			return true

--- a/pkg/eval/runtimeservice.go
+++ b/pkg/eval/runtimeservice.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/teramoby/speedle-plus/3rdparty/github.com/Knetic/govaluate"
 	"github.com/teramoby/speedle-plus/api/pms"
+	"github.com/teramoby/speedle-plus/pkg/errors"
 )
 
 type RuntimePolicyStore struct {
@@ -232,9 +233,16 @@ func (rtps *RuntimePolicyStore) convertService(service *pms.Service) *RuntimeSer
 	return rtService
 }
 
+// maxConditionLength is the maximum allowed length for a condition expression.
+// Conditions longer than this are rejected to prevent resource exhaustion attacks.
+const maxConditionLength = 4096
+
 func compileCondition(condition string, functions map[string]govaluate.ExpressionFunction) (*govaluate.EvaluableExpression, error) {
 	if len(condition) == 0 {
 		return nil, nil
+	}
+	if len(condition) > maxConditionLength {
+		return nil, errors.Errorf(errors.InvalidRequest, "condition expression exceeds maximum length of %d: len=%d", maxConditionLength, len(condition))
 	}
 
 	exp, err := govaluate.NewEvaluableExpressionWithFunctions(condition, functions)

--- a/pkg/store/etcd/discover.go
+++ b/pkg/store/etcd/discover.go
@@ -6,6 +6,7 @@ package etcd
 import (
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/teramoby/speedle-plus/api/ads"
@@ -67,7 +68,7 @@ func (s *Store) PutRequest(request *ads.RequestContext) (int64, error) {
 				go func() {
 				defer func() {
 					if r := recover(); r != nil {
-						log.Errorf("panic in DeleteRequests cleanup goroutine: %v", r)
+						log.Errorf("panic in DeleteRequests cleanup goroutine: %v\n%s", r, debug.Stack())
 					}
 				}()
 				if err := s.DeleteRequests(keys); err != nil {

--- a/pkg/store/etcd/etcdStore.go
+++ b/pkg/store/etcd/etcdStore.go
@@ -6,6 +6,7 @@ package etcd
 import (
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -620,7 +621,7 @@ func (s *Store) Watch() (pms.StorageChangeChannel, error) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				log.Errorf("panic in Watch outer goroutine: %v", r)
+				log.Errorf("panic in Watch outer goroutine: %v\n%s", r, debug.Stack())
 			}
 			close(evalChan)
 			// Note: s.stop is closed by StopWatch (guarded by stopOnce), not
@@ -635,9 +636,16 @@ func (s *Store) Watch() (pms.StorageChangeChannel, error) {
 	loop:
 		for {
 			//TODO: reload policy store in case missing any changes during watch failure
+			watchStarted := time.Now()
 			go watch(evalChan, s, errChan, stopChan)
 			select {
 			case err := <-errChan:
+				// If the watch ran for longer than the backoff ceiling, the
+				// connection was healthy for a while; reset the failure counter
+				// so the next retry starts with a short backoff.
+				if time.Since(watchStarted) > watchBackoffMax {
+					consecutiveFails = 0
+				}
 				consecutiveFails++
 				backoff := computeWatchBackoff(consecutiveFails)
 				log.Warningf("Error %v happens, restart watching after %v (failures: %d)...\n",
@@ -665,7 +673,7 @@ func watch(evalChan chan pms.StoreChangeEvent, s *Store, errChan chan error, sto
 	cli := s.client // Reuse existing client instead of creating a new one
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("panic in watch %v: %v", watchID, r)
+			log.Errorf("panic in watch %v: %v\n%s", watchID, r, debug.Stack())
 		}
 		log.Infof("Exiting watch %v...", watchID)
 	}()

--- a/pkg/store/file/fileStore.go
+++ b/pkg/store/file/fileStore.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -352,7 +353,7 @@ func (s *Store) Watch() (pms.StorageChangeChannel, error) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				log.Errorf("Panic in file Watch goroutine: %v", r)
+				log.Errorf("Panic in file Watch goroutine: %v\n%s", r, debug.Stack())
 			}
 			watcher.Close()
 			close(storeChangeChan)

--- a/pkg/store/mongodb/mongodbStore.go
+++ b/pkg/store/mongodb/mongodbStore.go
@@ -460,6 +460,23 @@ func (s *Store) Type() string {
 	return StoreType
 }
 
+// isValidFilterFieldName checks that a field name contains only alphanumeric
+// characters and underscores to prevent MongoDB operator injection.
+func isValidFilterFieldName(name string) bool {
+	for _, c := range name {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return len(name) > 0
+}
+
+// containsMongoOperatorChars returns true if s contains characters used in
+// MongoDB operator syntax ($, {, }, [, ]) which could enable filter injection.
+func containsMongoOperatorChars(s string) bool {
+	return strings.ContainsAny(s, "${}[]")
+}
+
 func parseFilter(filterStr string) (bson.D, error) {
 	if len(filterStr) == 0 {
 		return bson.D{{"$eq", bson.A{1, 1}}}, nil
@@ -468,6 +485,9 @@ func parseFilter(filterStr string) (bson.D, error) {
 	if len(values) == 2 {
 		field := values[0]
 		operator := values[1]
+		if !isValidFilterFieldName(field) {
+			return nil, errors.Errorf(errors.InvalidRequest, "invalid field name %q in filter: must be alphanumeric/underscore only", field)
+		}
 		switch operator {
 		case "pr":
 			return bson.D{{"$gt", bson.A{"$$p." + field, nil}}}, nil
@@ -480,6 +500,12 @@ func parseFilter(filterStr string) (bson.D, error) {
 		field := values[0]
 		operator := values[1]
 		target := values[2]
+		if !isValidFilterFieldName(field) {
+			return nil, errors.Errorf(errors.InvalidRequest, "invalid field name %q in filter: must be alphanumeric/underscore only", field)
+		}
+		if containsMongoOperatorChars(target) {
+			return nil, errors.Errorf(errors.InvalidRequest, "invalid target value %q in filter: must not contain MongoDB operator characters ($, {, }, [, ])", target)
+		}
 		switch operator {
 		case "eq":
 			return bson.D{{"$eq", bson.A{"$$p." + field, target}}}, nil

--- a/pkg/svcs/pmsimpl/systemLimitation.go
+++ b/pkg/svcs/pmsimpl/systemLimitation.go
@@ -93,6 +93,13 @@ func CheckPolicy(serviceName string, policy *pms.Policy, policyStore pms.PolicyS
 		return errors.New(errors.InvalidRequest, "no effect provided in policy.")
 	}
 
+	// Reject ResourceExpression longer than 1024 chars to prevent regex abuse.
+	for _, perm := range policy.Permissions {
+		if len(perm.ResourceExpression) > 1024 {
+			return errors.Errorf(errors.InvalidRequest, "resource expression exceeds maximum length of 1024: len=%d", len(perm.ResourceExpression))
+		}
+	}
+
 	// Check the number of Policy + RolePolicy
 	existingCount, err := getPolicyAndRolePolicyCount("", policyStore)
 	if nil != err {


### PR DESCRIPTION
## Security & Reliability Hardening

Fixes all remaining findings from the final review sweep:

1. **SSRF redirect bypass** (High) — Added `CheckRedirect` to HTTP clients that validates each redirect target against SSRF rules, blocking open-redirect-based SSRF
2. **ReDoS guard** (Medium) — Added 1024-char limit on regex resource expressions (Go's RE2 prevents backtracking but long patterns still cost); rejected at policy registration
3. **MongoDB filter injection** (Medium) — Validated filter field names (alphanumeric+underscore only) and reject target values containing `${}[]`
4. **Unbounded caches** (Medium) — compiledRegexCache capped at 10k entries; FuncResultCache capped at 50k entries
5. **Panic stack traces** (Low) — All panic recovery blocks now log `debug.Stack()` for debuggability
6. **etcd backoff reset** (Low) — consecutiveFails resets after successful watch run
7. **Condition length limit** (Low) — compileCondition rejects expressions >4096 chars

🤖 Generated with Claude Code